### PR TITLE
ensure params$value is a vector

### DIFF
--- a/R/plot_param.R
+++ b/R/plot_param.R
@@ -8,6 +8,7 @@
 plot_param <- function(fit, out_only = FALSE, base_size = 8) {
 
   if(all(c("optimise", "lower", "upper") %in% names(fit$params))) {
+    if (is.list(fit$params$value)) fit$params$value <- unlist(fit$params$value)
     dat <- fit$params %>%
       dplyr::filter(.data$optimise == 1) %>%
       dplyr::mutate(rho = (.data$value-.data$lower)/(.data$upper - .data$lower))


### PR DESCRIPTION
if params$value is a list (which it typically is) it is turned into vector prior to calculating rho